### PR TITLE
Key-based pagination fallback for chains that cap store scans (Sei)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ You can pass the artuments to the executable file to configure it. Here is the p
 - `--node` - the gRPC node URL. Defaults to `localhost:9090`
 - `--tendermint-rpc` - Tendermint RPC URL to query node stats (specifically `chain-id`). Defaults to `http://localhost:26657`
 - `--log-devel` - logger level. Defaults to `info`. You can set it to `debug` to make it more verbose.
-- `--limit` - pagination limit for gRPC requests. Defaults to 1000.
+- `--limit` - page size for paginated gRPC requests. Results are fetched page by page until the node reports no more pages. Defaults to 1000.
+- `--max-delegations` - maximum number of per-delegator entries to fetch for a validator (`0` for no limit). Each entry becomes its own Prometheus time series, so this caps both scrape cost and cardinality. Defaults to 100000.
+- `--skip-validator-delegations` - do not collect `cosmos_validator_delegations` at all. Useful on chains with very large delegator sets (e.g. Sei), where the per-delegator series are expensive for both the node and Prometheus.
 - `--json` - output logs as JSON. Useful if you don't read it on servers but instead use logging aggregation solutions such as ELK stack.
 - `--refresh-interval` - how often metrics may be re-collected from the node. Scrapes in between are served from an in-memory cache, so the node sees at most one collection per endpoint per interval no matter how many Prometheus instances scrape the exporter. Defaults to `30s`.
 - `--grpc-timeout` - timeout for collecting metrics from the node. Defaults to `15s`.

--- a/collect_integration_test.go
+++ b/collect_integration_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"math/big"
 	"net"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -16,6 +19,8 @@ import (
 	sdkmath "cosmossdk.io/math"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	querytypes "github.com/cosmos/cosmos-sdk/types/query"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -28,9 +33,11 @@ import (
 
 type fakeStakingServer struct {
 	stakingtypes.UnimplementedQueryServer
-	validators []stakingtypes.Validator
-	pool       stakingtypes.Pool
-	bondDenom  string
+	validators             []stakingtypes.Validator
+	pool                   stakingtypes.Pool
+	bondDenom              string
+	delegations            []stakingtypes.DelegationResponse
+	rejectOffsetPagination bool
 }
 
 func (s *fakeStakingServer) Validator(ctx context.Context, req *stakingtypes.QueryValidatorRequest) (*stakingtypes.QueryValidatorResponse, error) {
@@ -57,7 +64,39 @@ func (s *fakeStakingServer) Pool(ctx context.Context, req *stakingtypes.QueryPoo
 }
 
 func (s *fakeStakingServer) ValidatorDelegations(ctx context.Context, req *stakingtypes.QueryValidatorDelegationsRequest) (*stakingtypes.QueryValidatorDelegationsResponse, error) {
-	return &stakingtypes.QueryValidatorDelegationsResponse{}, nil
+	if s.delegations == nil {
+		return &stakingtypes.QueryValidatorDelegationsResponse{}, nil
+	}
+
+	page := req.Pagination
+	// Sei rejects offset-mode queries that would scan too much of the store.
+	if s.rejectOffsetPagination && len(page.GetKey()) == 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			"scanned more than 10000 entries without filling the page; use key-based pagination instead")
+	}
+
+	start := 0
+	if key := page.GetKey(); len(key) > 0 && !bytes.Equal(key, firstPageKey) {
+		parsed, err := strconv.Atoi(string(key))
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "bad page key %q", key)
+		}
+		start = parsed
+	}
+
+	end := start + int(page.GetLimit())
+	if end > len(s.delegations) {
+		end = len(s.delegations)
+	}
+
+	response := &stakingtypes.QueryValidatorDelegationsResponse{
+		DelegationResponses: s.delegations[start:end],
+		Pagination:          &querytypes.PageResponse{},
+	}
+	if end < len(s.delegations) {
+		response.Pagination.NextKey = []byte(strconv.Itoa(end))
+	}
+	return response, nil
 }
 
 func (s *fakeStakingServer) ValidatorUnbondingDelegations(ctx context.Context, req *stakingtypes.QueryValidatorUnbondingDelegationsRequest) (*stakingtypes.QueryValidatorUnbondingDelegationsResponse, error) {
@@ -153,6 +192,8 @@ func setTestGlobals(t *testing.T) {
 	ConsensusNodePrefix = "seivalcons"
 	ConstLabels = prometheus.Labels{"chain_id": "sei-test-1"}
 	Limit = 1000
+	MaxDelegations = 0
+	SkipValidatorDelegations = false
 }
 
 func makeTestValidator(t *testing.T, operator, moniker string, missedBlocksKey *ed25519.PubKey) stakingtypes.Validator {
@@ -301,6 +342,81 @@ func TestCollectValidatorMissedBlocksUsesDerivedBech32ConsAddress(t *testing.T) 
 		if addr != consAddr {
 			t.Errorf("SigningInfo called with %q, want derived bech32 %q", addr, consAddr)
 		}
+	}
+}
+
+func TestCollectValidatorDelegationsOnChainRejectingOffsetPagination(t *testing.T) {
+	setTestGlobals(t)
+	Limit = 100
+	MaxDelegations = 0
+
+	key := ed25519.GenPrivKey().PubKey().(*ed25519.PubKey)
+	validator := makeTestValidator(t, "seivaloper1ccc", "noders", key)
+
+	const delegatorCount = 250
+	delegations := make([]stakingtypes.DelegationResponse, 0, delegatorCount)
+	for i := 0; i < delegatorCount; i++ {
+		delegations = append(delegations, stakingtypes.DelegationResponse{
+			Delegation: stakingtypes.Delegation{
+				DelegatorAddress: fmt.Sprintf("sei1delegator%d", i),
+				ValidatorAddress: "seivaloper1ccc",
+			},
+			Balance: sdk.NewCoin("usei", sdkmath.NewInt(2_000_000)),
+		})
+	}
+
+	staking := &fakeStakingServer{
+		validators:             []stakingtypes.Validator{validator},
+		delegations:            delegations,
+		rejectOffsetPagination: true,
+	}
+	conn := startFakeNode(t, staking, &fakeSlashingServer{})
+
+	registry, err := collectValidatorMetrics(context.Background(), conn, "seivaloper1ccc")
+	if err != nil {
+		t.Fatalf("collectValidatorMetrics failed: %v", err)
+	}
+
+	// Every delegator must be present despite the node refusing offset mode.
+	for _, i := range []int{0, 149, delegatorCount - 1} {
+		value, found := findGaugeValue(t, registry, "cosmos_validator_delegations", map[string]string{
+			"delegated_by": fmt.Sprintf("sei1delegator%d", i),
+		})
+		if !found {
+			t.Fatalf("delegation from sei1delegator%d missing — key-based pagination fallback did not collect all pages", i)
+		}
+		if value != 2 {
+			t.Errorf("delegation value = %v, want 2 (2_000_000 / 1_000_000)", value)
+		}
+	}
+}
+
+func TestCollectValidatorSkipsDelegationsWhenDisabled(t *testing.T) {
+	setTestGlobals(t)
+	SkipValidatorDelegations = true
+	t.Cleanup(func() { SkipValidatorDelegations = false })
+
+	key := ed25519.GenPrivKey().PubKey().(*ed25519.PubKey)
+	validator := makeTestValidator(t, "seivaloper1ddd", "noders", key)
+	staking := &fakeStakingServer{
+		validators: []stakingtypes.Validator{validator},
+		delegations: []stakingtypes.DelegationResponse{{
+			Delegation: stakingtypes.Delegation{DelegatorAddress: "sei1x", ValidatorAddress: "seivaloper1ddd"},
+			Balance:    sdk.NewCoin("usei", sdkmath.NewInt(1)),
+		}},
+	}
+	conn := startFakeNode(t, staking, &fakeSlashingServer{})
+
+	registry, err := collectValidatorMetrics(context.Background(), conn, "seivaloper1ddd")
+	if err != nil {
+		t.Fatalf("collectValidatorMetrics failed: %v", err)
+	}
+
+	if _, found := findGaugeValue(t, registry, "cosmos_validator_delegations", nil); found {
+		t.Error("per-delegator metrics present despite --skip-validator-delegations")
+	}
+	if _, found := findGaugeValue(t, registry, "cosmos_validator_tokens", nil); !found {
+		t.Error("other validator metrics must still be collected")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ var (
 	RefreshInterval time.Duration
 	GRPCTimeout     time.Duration
 	TLSEnabled      bool
+
+	MaxDelegations           int
+	SkipValidatorDelegations bool
 )
 
 var log = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).With().Timestamp().Logger()
@@ -445,6 +448,8 @@ func main() {
 	rootCmd.PersistentFlags().DurationVar(&RefreshInterval, "refresh-interval", 30*time.Second, "How often metrics may be re-collected from the node; scrapes in between are served from cache")
 	rootCmd.PersistentFlags().DurationVar(&GRPCTimeout, "grpc-timeout", 15*time.Second, "Timeout for collecting metrics from the node")
 	rootCmd.PersistentFlags().BoolVar(&TLSEnabled, "tls", false, "Use TLS for the gRPC connection (e.g. public endpoints on port 443)")
+	rootCmd.PersistentFlags().IntVar(&MaxDelegations, "max-delegations", 100000, "Maximum number of per-delegator entries to fetch for a validator (0 for no limit). Each entry becomes its own time series")
+	rootCmd.PersistentFlags().BoolVar(&SkipValidatorDelegations, "skip-validator-delegations", false, "Do not collect cosmos_validator_delegations. Useful on chains with very large delegator sets, where the per-delegator series are expensive for both the node and Prometheus")
 
 	rootCmd.PersistentFlags().StringVar(&Prefix, "bech-prefix", "persistence", "Bech32 global prefix")
 	rootCmd.PersistentFlags().StringVar(&AccountPrefix, "bech-account-prefix", "", "Bech32 account prefix")

--- a/pagination.go
+++ b/pagination.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	querytypes "github.com/cosmos/cosmos-sdk/types/query"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// firstPageKey starts a key-based scan from the very beginning of the store:
+// it sorts before any real entry, so the iterator behaves like an unkeyed one
+// while still selecting the node's key-pagination code path.
+var firstPageKey = []byte{0x00}
+
+// pageFetcher runs one paginated gRPC query and returns the page items plus
+// the pagination response carrying the next key.
+type pageFetcher[T any] func(ctx context.Context, page *querytypes.PageRequest) ([]T, *querytypes.PageResponse, error)
+
+// isScanLimitError reports whether the node refused an offset-mode query
+// because it would scan too many store entries. sei-cosmos enforces this for
+// queries that filter over a large store (e.g. ValidatorDelegations) and asks
+// the client to switch to key-based pagination.
+func isScanLimitError(err error) bool {
+	if status.Code(err) != codes.InvalidArgument && status.Code(err) != codes.Internal {
+		return false
+	}
+	return strings.Contains(err.Error(), "scanned more than")
+}
+
+// paginateAll walks every page of a paginated query and returns the combined
+// result.
+//
+// The first page is requested the plain way, exactly as before; if the node
+// rejects it with a scan-limit error, the whole walk is retried using
+// key-based pagination, which such nodes serve without scanning the entire
+// store up front.
+//
+// maxItems caps the total number of collected items (0 means no cap) so a
+// validator with a very large delegator set cannot stall a scrape.
+func paginateAll[T any](ctx context.Context, pageLimit uint64, maxItems int, fetch pageFetcher[T]) ([]T, error) {
+	results, err := paginateFrom(ctx, nil, pageLimit, maxItems, fetch)
+	if err == nil {
+		return results, nil
+	}
+	if !isScanLimitError(err) {
+		return nil, err
+	}
+
+	log.Debug().Err(err).Msg("Node rejected offset pagination, retrying with key-based pagination")
+	return paginateFrom(ctx, firstPageKey, pageLimit, maxItems, fetch)
+}
+
+func paginateFrom[T any](ctx context.Context, startKey []byte, pageLimit uint64, maxItems int, fetch pageFetcher[T]) ([]T, error) {
+	if pageLimit == 0 {
+		pageLimit = 100
+	}
+
+	var (
+		results []T
+		nextKey = startKey
+	)
+
+	for {
+		limit := pageLimit
+		if maxItems > 0 {
+			remaining := maxItems - len(results)
+			if remaining <= 0 {
+				return results, nil
+			}
+			if uint64(remaining) < limit {
+				limit = uint64(remaining)
+			}
+		}
+
+		items, pageResponse, err := fetch(ctx, &querytypes.PageRequest{
+			Key:   nextKey,
+			Limit: limit,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, items...)
+
+		key := pageResponse.GetNextKey()
+		if len(key) == 0 {
+			return results, nil
+		}
+		if bytes.Equal(key, nextKey) {
+			return nil, fmt.Errorf("node returned the same pagination key twice (%d items collected)", len(results))
+		}
+		nextKey = key
+	}
+}

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	querytypes "github.com/cosmos/cosmos-sdk/types/query"
+)
+
+// seiLikePager emulates sei-cosmos FilteredPaginate: offset-mode requests fail
+// once the scan exceeds maxScan entries without filling the page, while
+// key-mode requests are served page by page.
+type seiLikePager struct {
+	totalItems int
+	maxScan    int
+	calls      int
+	offsetUsed bool
+}
+
+func (p *seiLikePager) fetch(ctx context.Context, page *querytypes.PageRequest) ([]string, *querytypes.PageResponse, error) {
+	p.calls++
+
+	if len(page.Key) == 0 && p.totalItems > p.maxScan {
+		p.offsetUsed = true
+		return nil, nil, status.Errorf(codes.InvalidArgument,
+			"scanned more than %d entries without filling the page; use key-based pagination instead", p.maxScan)
+	}
+
+	start := 0
+	if len(page.Key) > 0 && !bytes.Equal(page.Key, firstPageKey) {
+		if _, err := fmt.Sscanf(string(page.Key), "item-%d", &start); err != nil {
+			return nil, nil, fmt.Errorf("bad key %q", page.Key)
+		}
+	}
+
+	end := start + int(page.Limit)
+	if end > p.totalItems {
+		end = p.totalItems
+	}
+
+	items := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		items = append(items, fmt.Sprintf("item-%d", i))
+	}
+
+	response := &querytypes.PageResponse{}
+	if end < p.totalItems {
+		response.NextKey = []byte(fmt.Sprintf("item-%d", end))
+	}
+	return items, response, nil
+}
+
+func TestPaginateAllCollectsEveryPage(t *testing.T) {
+	pager := &seiLikePager{totalItems: 2500, maxScan: 10000}
+
+	items, err := paginateAll(context.Background(), 1000, 0, pager.fetch)
+	if err != nil {
+		t.Fatalf("paginateAll failed: %v", err)
+	}
+	if len(items) != 2500 {
+		t.Errorf("collected %d items, want 2500", len(items))
+	}
+	if pager.calls != 3 {
+		t.Errorf("made %d requests, want 3 pages", pager.calls)
+	}
+	if items[0] != "item-0" || items[2499] != "item-2499" {
+		t.Errorf("unexpected boundaries: first=%q last=%q", items[0], items[2499])
+	}
+}
+
+func TestPaginateAllRecoversFromSeiScanLimit(t *testing.T) {
+	// 50k delegations: the offset-mode probe trips Sei's scan limit and the
+	// walk must transparently fall back to key-based pagination.
+	pager := &seiLikePager{totalItems: 50_000, maxScan: 10_000}
+
+	items, err := paginateAll(context.Background(), 1000, 0, pager.fetch)
+	if err != nil {
+		t.Fatalf("paginateAll failed on Sei-like node: %v", err)
+	}
+	if !pager.offsetUsed {
+		t.Error("expected the first attempt to use offset mode (standard-chain path)")
+	}
+	if len(items) != 50_000 {
+		t.Errorf("collected %d items, want 50000", len(items))
+	}
+}
+
+func TestPaginateAllKeepsOffsetModeOnStandardChains(t *testing.T) {
+	// A chain without a scan limit must never see a key-mode request.
+	var sawKey bool
+	fetch := func(ctx context.Context, page *querytypes.PageRequest) ([]string, *querytypes.PageResponse, error) {
+		if len(page.Key) > 0 {
+			sawKey = true
+		}
+		return []string{"a", "b"}, &querytypes.PageResponse{}, nil
+	}
+
+	if _, err := paginateAll(context.Background(), 1000, 0, fetch); err != nil {
+		t.Fatalf("paginateAll failed: %v", err)
+	}
+	if sawKey {
+		t.Error("key-based pagination was used on a chain that accepted offset mode")
+	}
+}
+
+func TestPaginateAllRespectsMaxItems(t *testing.T) {
+	pager := &seiLikePager{totalItems: 50_000, maxScan: 10_000}
+
+	items, err := paginateAll(context.Background(), 1000, 2500, pager.fetch)
+	if err != nil {
+		t.Fatalf("paginateAll failed: %v", err)
+	}
+	if len(items) != 2500 {
+		t.Errorf("collected %d items, want the 2500 cap", len(items))
+	}
+}
+
+func TestPaginateAllPropagatesRealErrors(t *testing.T) {
+	failing := func(ctx context.Context, page *querytypes.PageRequest) ([]string, *querytypes.PageResponse, error) {
+		return nil, nil, fmt.Errorf("node unreachable")
+	}
+
+	if _, err := paginateAll(context.Background(), 1000, 0, failing); err == nil {
+		t.Fatal("expected an error to propagate")
+	}
+}
+
+func TestPaginateAllStopsOnRepeatedKey(t *testing.T) {
+	// A node that keeps returning the same NextKey must not loop forever.
+	stuck := func(ctx context.Context, page *querytypes.PageRequest) ([]string, *querytypes.PageResponse, error) {
+		return []string{"x"}, &querytypes.PageResponse{NextKey: []byte("same")}, nil
+	}
+
+	if _, err := paginateAll(context.Background(), 10, 0, stuck); err == nil {
+		t.Fatal("expected an error when the node repeats the same page key")
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -233,21 +233,33 @@ func collectValidatorMetrics(ctx context.Context, grpcConn *grpc.ClientConn, add
 	var wg sync.WaitGroup
 
 	goSafe(&wg, func() {
+		if SkipValidatorDelegations {
+			sublogger.Debug().
+				Str("address", address).
+				Msg("Skipping per-delegator metrics (--skip-validator-delegations)")
+			return
+		}
+
 		sublogger.Debug().
 			Str("address", address).
 			Msg("Started querying validator delegations")
 		queryStart := time.Now()
 
 		stakingClient := stakingtypes.NewQueryClient(grpcConn)
-		stakingRes, err := stakingClient.ValidatorDelegations(
-			ctx,
-			&stakingtypes.QueryValidatorDelegationsRequest{
-				ValidatorAddr: address,
-				Pagination: &querytypes.PageRequest{
-					Limit: Limit,
-				},
-			},
-		)
+		delegations, err := paginateAll(ctx, Limit, MaxDelegations,
+			func(ctx context.Context, page *querytypes.PageRequest) ([]stakingtypes.DelegationResponse, *querytypes.PageResponse, error) {
+				res, err := stakingClient.ValidatorDelegations(
+					ctx,
+					&stakingtypes.QueryValidatorDelegationsRequest{
+						ValidatorAddr: address,
+						Pagination:    page,
+					},
+				)
+				if err != nil {
+					return nil, nil, err
+				}
+				return res.DelegationResponses, res.Pagination, nil
+			})
 		if err != nil {
 			sublogger.Warn().
 				Str("address", address).
@@ -258,10 +270,11 @@ func collectValidatorMetrics(ctx context.Context, grpcConn *grpc.ClientConn, add
 
 		sublogger.Debug().
 			Str("address", address).
+			Int("delegations", len(delegations)).
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validator delegations")
 
-		for _, delegation := range stakingRes.DelegationResponses {
+		for _, delegation := range delegations {
 			if value, err := strconv.ParseFloat(delegation.Balance.Amount.String(), 64); err != nil {
 				sublogger.Error().
 					Err(err).
@@ -498,14 +511,14 @@ func collectValidatorMetrics(ctx context.Context, grpcConn *grpc.ClientConn, add
 		queryStart := time.Now()
 
 		stakingClient := stakingtypes.NewQueryClient(grpcConn)
-		stakingRes, err := stakingClient.Validators(
-			ctx,
-			&stakingtypes.QueryValidatorsRequest{
-				Pagination: &querytypes.PageRequest{
-					Limit: Limit,
-				},
-			},
-		)
+		validators, err := paginateAll(ctx, Limit, 0,
+			func(ctx context.Context, page *querytypes.PageRequest) ([]stakingtypes.Validator, *querytypes.PageResponse, error) {
+				res, err := stakingClient.Validators(ctx, &stakingtypes.QueryValidatorsRequest{Pagination: page})
+				if err != nil {
+					return nil, nil, err
+				}
+				return res.Validators, res.Pagination, nil
+			})
 		if err != nil {
 			sublogger.Warn().
 				Str("address", address).
@@ -513,8 +526,6 @@ func collectValidatorMetrics(ctx context.Context, grpcConn *grpc.ClientConn, add
 				Msg("Could not get validators list")
 			return
 		}
-
-		validators := stakingRes.Validators
 
 		sort.Slice(validators, func(i, j int) bool {
 			return validators[i].DelegatorShares.GT(validators[j].DelegatorShares)

--- a/validators.go
+++ b/validators.go
@@ -131,14 +131,14 @@ func collectValidatorsMetrics(ctx context.Context, grpcConn *grpc.ClientConn) (*
 		queryStart := time.Now()
 
 		stakingClient := stakingtypes.NewQueryClient(grpcConn)
-		validatorsResponse, err := stakingClient.Validators(
-			ctx,
-			&stakingtypes.QueryValidatorsRequest{
-				Pagination: &querytypes.PageRequest{
-					Limit: Limit,
-				},
-			},
-		)
+		fetched, err := paginateAll(ctx, Limit, 0,
+			func(ctx context.Context, page *querytypes.PageRequest) ([]stakingtypes.Validator, *querytypes.PageResponse, error) {
+				res, err := stakingClient.Validators(ctx, &stakingtypes.QueryValidatorsRequest{Pagination: page})
+				if err != nil {
+					return nil, nil, err
+				}
+				return res.Validators, res.Pagination, nil
+			})
 		if err != nil {
 			validatorsErr = fmt.Errorf("could not get validators: %w", err)
 			return
@@ -147,7 +147,7 @@ func collectValidatorsMetrics(ctx context.Context, grpcConn *grpc.ClientConn) (*
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validators")
-		validators = validatorsResponse.Validators
+		validators = fetched
 
 		sort.Slice(validators, func(i, j int) bool {
 			return validators[i].DelegatorShares.GT(validators[j].DelegatorShares)
@@ -159,14 +159,14 @@ func collectValidatorsMetrics(ctx context.Context, grpcConn *grpc.ClientConn) (*
 		queryStart := time.Now()
 
 		slashingClient := slashingtypes.NewQueryClient(grpcConn)
-		signingInfosResponse, err := slashingClient.SigningInfos(
-			ctx,
-			&slashingtypes.QuerySigningInfosRequest{
-				Pagination: &querytypes.PageRequest{
-					Limit: Limit,
-				},
-			},
-		)
+		fetched, err := paginateAll(ctx, Limit, 0,
+			func(ctx context.Context, page *querytypes.PageRequest) ([]slashingtypes.ValidatorSigningInfo, *querytypes.PageResponse, error) {
+				res, err := slashingClient.SigningInfos(ctx, &slashingtypes.QuerySigningInfosRequest{Pagination: page})
+				if err != nil {
+					return nil, nil, err
+				}
+				return res.Info, res.Pagination, nil
+			})
 		if err != nil {
 			sublogger.Warn().
 				Err(err).
@@ -177,7 +177,7 @@ func collectValidatorsMetrics(ctx context.Context, grpcConn *grpc.ClientConn) (*
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validator signing infos")
-		signingInfos = signingInfosResponse.Info
+		signingInfos = fetched
 	})
 
 	goSafe(&wg, func() {


### PR DESCRIPTION
## Problem

On a real Sei validator node, `cosmos_validator_delegations` silently disappears:

```
WRN Could not get validator delegations error="rpc error: code = Internal desc = rpc error: code = InvalidArgument desc = scanned more than 10000 entries without filling the page; use key-based pagination instead" address=seivaloper1yw2kzact9futl537c83ukal7zf25f6gmm3e390
```

Confirmed in [sei-cosmos `filtered_pagination.go`](https://github.com/sei-protocol/sei-chain/blob/main/sei-cosmos/types/query/filtered_pagination.go): Sei enforces a `MaxScanLimit` (10000) on offset-mode queries. `ValidatorDelegations` filters over the whole delegation store, so on a chain of Sei's size the scan blows past the limit before a page is filled. Key-based pagination is served normally.

## Fix

- `paginateAll()` requests the first page exactly as before (**no behaviour change on standard chains**) and, only if the node answers with a scan-limit error, transparently retries the walk using key-based pagination.
- All pages are now fetched instead of just the first `--limit` entries. This also fixes silently truncated results on any chain with more validators/signing infos than `--limit`.
- Applied to `ValidatorDelegations`, `Validators` and `SigningInfos`.

## New flags

- `--max-delegations` (default 100000) — cap per-delegator entries. Each one is its own time series, so this bounds both scrape cost and Prometheus cardinality.
- `--skip-validator-delegations` — turn that metric off entirely, which is the sensible setting on chains with very large delegator sets.

## Test plan
- [x] Unit tests for `paginateAll`: multi-page walk, Sei-like pager that rejects offset mode, `maxItems` cap, error propagation, repeated-key loop guard
- [x] Regression test that standard chains never receive a key-mode request
- [x] Integration test over bufconn where the fake node rejects offset pagination — all 250 delegations across 3 pages are collected
- [x] `go vet`, full suite with `-race`
- [ ] Verify on the Sei validator node that `cosmos_validator_delegations` now appears